### PR TITLE
add show pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,8 @@ gem 'devise-i18n'
 
 #Markdown適用
 gem 'redcarpet', '~> 2.3.0'
-
-#シンタックスハイライト
 gem 'coderay'
+#シンタックスハイライト
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,12 @@ gem 'activeadmin'
 gem 'rails-i18n', '~> 6.0.0' # For 6.0.0 or higher
 gem 'devise-i18n'
 
+#Markdown適用
+gem 'redcarpet', '~> 2.3.0'
+
+#シンタックスハイライト
+gem 'coderay'
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,6 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-bootstrap-views (1.1.0)
     devise-i18n (1.9.1)
       devise (>= 4.7.1)
     erubi (1.9.0)
@@ -202,6 +201,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (2.3.0)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -259,8 +259,8 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
-  devise-bootstrap-views (~> 1.0)
   devise-i18n
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
@@ -271,6 +271,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n (~> 6.0.0)
+  redcarpet (~> 2.3.0)
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,10 +1,9 @@
 @import "bootstrap/scss/bootstrap";
 
 main {
-  max-width: 700px;
-  margin: 0 auto;
-  padding: 1rem;
+max-width: 700px;
+margin: 0 auto;
+padding: 1rem;
 }
 
 
-  

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -1,7 +1,11 @@
 class AwsTextsController < ApplicationController
 
-def index
-	@aws_texts = AwsText.all
-end
+	def index
+		@aws_texts = AwsText.all
+	end
+
+	def show
+		@aws_text = AwsText.find(params[:id])
+	end
 
 end

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -1,11 +1,12 @@
 class AwsTextsController < ApplicationController
 
-	def index
-		@aws_texts = AwsText.all
-	end
+  def index
+    @aws_texts = AwsText.all
+  end
 
-	def show
-		@aws_text = AwsText.find(params[:id])
-	end
+  def show
+    @aws_text = AwsText.find(params[:id])
+  end
 
 end
+

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,21 @@
+module MarkdownHelper
+  def markdown(text)
+    options = {
+      hard_wrap:       true,
+      space_after_headers: true,
+    }
+
+    extensions = {
+      autolink:           true,
+      no_intra_emphasis:  true,
+      fenced_code_blocks: true,
+    }
+
+    unless @markdown
+      renderer = Redcarpet::Render::HTML.new(options)
+      @markdown = Redcarpet::Markdown.new(renderer, extensions)
+    end
+
+    @markdown.render(text).html_safe
+  end
+end

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -2,26 +2,26 @@
   <div class="text-center mt-5 mb-4">
     <h2>AWS講座</h2>
   </div>
-    <p>注意！！！：AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。</p>
+  <p>注意！！！：AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。</p>
 
-    <table class="table table-striped">
-      <thead class="aws-table-head text-white bg-primary">
+  <table class="table table-striped">
+    <thead class="aws-table-head text-white bg-primary">
       <tr>
         <th class="w-1">No.</th>
         <th class="w-5">内容</th>
       </tr>
-      </thead>
-        <tbody>
-          <% @aws_texts.each.with_index(1) do |aws_text, i|%>
-          <tr>
-            <td>
-              <%= i %>
-            </td>
-            <td>
-              <%= link_to aws_text.title, aws_text_path(aws_text) %>
-            </td>
-          </tr>
-          <% end %>
-        </tbody>
-    </table>
+    </thead>
+    <tbody>
+      <% @aws_texts.each.with_index(1) do |aws_text, i|%>
+      <tr>
+        <td>
+          <%= i %>
+        </td>
+        <td>
+          <%= link_to aws_text.title, aws_text_path(aws_text) %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
 </div>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,2 @@
+<%= markdown(@aws_text.title) %>
+<%= markdown(@aws_text.content) %>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,2 +1,2 @@
-<%= markdown(@aws_text.title) %>
+<h1><%= @aws_text.title %></h1>
 <%= markdown(@aws_text.content) %>


### PR DESCRIPTION
AWSテキスト教材詳細ページの実装を行いました。
ご確認お願いします。
```
1. 一覧ページの「内容」から詳細ページに移動できるようにした。
2. 詳細ページにMarkdownを表示を適用した。
```